### PR TITLE
refactor(core): group links in header

### DIFF
--- a/src/core/Header/Header.module.css
+++ b/src/core/Header/Header.module.css
@@ -40,3 +40,25 @@
     }
   }
 }
+.active {
+  background-color: #040d1b;
+}
+
+.subLink {
+  width: 100%;
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+  border-radius: var(--mantine-radius-md);
+  &[aria-disabled] {
+    color: var(--mantine-color-dimmed);
+  }
+
+  @mixin hover {
+    &:not([aria-disabled]) {
+      background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-7));
+    }
+  }
+
+  &.active {
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-7));
+  }
+}

--- a/src/core/Header/Header.tsx
+++ b/src/core/Header/Header.tsx
@@ -1,8 +1,23 @@
 import { t } from "@lingui/core/macro";
-import { Anchor, AppShellHeader, Box, Burger, Container, Group, Text } from "@mantine/core";
+import {
+  Anchor,
+  AppShellHeader,
+  Box,
+  Burger,
+  Center,
+  Container,
+  Divider,
+  Group,
+  HoverCard,
+  SimpleGrid,
+  Text,
+  ThemeIcon,
+  UnstyledButton
+} from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import {
   IconBrandGithub,
+  IconChevronDown,
   IconClipboardCheck,
   IconDatabase,
   IconFileCertificate,
@@ -10,70 +25,198 @@ import {
   IconPackage,
   IconSettings
 } from "@tabler/icons-react";
+import cx from "clsx";
 import { useMemo } from "react";
-import { Link, NavLink } from "react-router";
+import { Link, NavLink, useLocation } from "react-router";
 import { useAppContext } from "../context/AppContext";
 import IconWrapper from "../IconWrapper";
 import classes from "./Header.module.css";
+
+type Link1 = {
+  id: string;
+  label: string;
+  disabled?: boolean;
+  links: Link2[];
+  icon: typeof IconSettings;
+};
+type Link2 = {
+  link: string;
+  label: string;
+  disabled?: boolean;
+  icon: typeof IconSettings;
+  description?: string;
+};
+type AllLinks = Link1 | Link2;
+
 export function Header() {
   const [opened, { toggle }] = useDisclosure(false);
   const { repoStatus } = useAppContext();
+  const location = useLocation();
 
-  const links = useMemo(() => {
+  const links: AllLinks[] = useMemo(() => {
     return [
       {
-        link: "/snapshots",
+        id: "snapshots-section",
         label: t`Snapshots`,
         disabled: !repoStatus.connected,
-        icon: IconPackage
+        icon: IconPackage,
+        links: [
+          {
+            link: "/snapshots",
+            label: t`Snapshots`,
+            disabled: !repoStatus.connected,
+            icon: IconPackage,
+            description: t`Manage snapshots`
+          },
+          {
+            link: "/mounts",
+            label: t`Mounts`,
+            disabled: !repoStatus.connected,
+            icon: IconFolderBolt,
+            description: t`Manage mounted snapshots`
+          }
+        ]
       },
       {
-        link: "/mounts",
-        label: t`Mounts`,
-        disabled: !repoStatus.connected,
-        icon: IconFolderBolt
-      },
-      {
-        link: "/policies",
-        label: t`Policies`,
-        disabled: !repoStatus.connected,
-        icon: IconFileCertificate
+        id: "repo-section",
+        label: t`Repository`,
+        icon: IconDatabase,
+        links: [
+          {
+            link: "/repo",
+            label: t`Status`,
+            icon: IconDatabase,
+            description: t`Manage repository status and configuration`
+          },
+          {
+            link: "/policies",
+            label: t`Policies`,
+            disabled: !repoStatus.connected,
+            icon: IconFileCertificate,
+            description: t`Manage snapshot policies for this repository`
+          }
+        ]
       },
       { link: "/tasks", label: t`Tasks`, icon: IconClipboardCheck },
-      { link: "/repo", label: t`Repository`, icon: IconDatabase },
       { link: "/preferences", label: t`Preferences`, icon: IconSettings },
       {
         link: "ext:https://github.com/joachimdalen/kopia-alternate-ui",
         label: "GitHub",
         icon: IconBrandGithub
       }
-    ];
+    ] satisfies AllLinks[];
   }, [repoStatus]);
 
-  const items = links.map((link) =>
-    link.disabled ? (
-      <a key={link.label} aria-disabled className={classes.link}>
-        <Group gap={5}>
-          <IconWrapper icon={link.icon} size={14} />
-          {link.label}
-        </Group>
-      </a>
-    ) : link.link.startsWith("ext:") ? (
-      <Anchor key={link.label} href={link.link.replace("ext:", "")} className={classes.link} target="_blank">
-        <Group gap={5}>
-          <IconWrapper icon={link.icon} size={14} />
-          {link.label}
-        </Group>
-      </Anchor>
-    ) : (
+  const items = links.map((link) => {
+    if ("links" in link) {
+      const links2 = link.links.map((item) => {
+        const body = (
+          <Group wrap="nowrap" align="flex-start">
+            <ThemeIcon size={34} variant="default" radius="md">
+              <IconWrapper icon={item.icon} size={22} />
+            </ThemeIcon>
+            <div>
+              <Text size="sm" fw={500}>
+                {item.label}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {item.description}
+              </Text>
+            </div>
+          </Group>
+        );
+
+        if (item.disabled) {
+          return (
+            <a
+              key={link.label}
+              aria-disabled
+              className={cx(classes.subLink, { [classes.active]: item.link === location.pathname })}
+            >
+              {body}
+            </a>
+          );
+        }
+
+        return (
+          <UnstyledButton
+            className={cx(classes.subLink, { [classes.active]: item.link === location.pathname })}
+            key={item.link}
+            component={NavLink}
+            to={item.link}
+          >
+            {body}
+          </UnstyledButton>
+        );
+      });
+      return (
+        <HoverCard
+          width={600}
+          position="bottom"
+          radius="md"
+          shadow="md"
+          withinPortal
+          key={link.id}
+          disabled={link.links.every((x) => x.disabled)}
+        >
+          <HoverCard.Target>
+            <UnstyledButton
+              className={cx(classes.link, { [classes.active]: link.links.some((x) => x.link === location.pathname) })}
+            >
+              <Center>
+                <IconWrapper icon={link.icon} size={14} />
+                <Box component="span" mx={5}>
+                  {link.label}
+                </Box>
+                <IconWrapper icon={IconChevronDown} size={14} />
+              </Center>
+            </UnstyledButton>
+          </HoverCard.Target>
+
+          <HoverCard.Dropdown style={{ overflow: "hidden" }}>
+            <Text fw={500} px="md">
+              {link.label}
+            </Text>
+
+            <Divider my="sm" />
+
+            <SimpleGrid cols={2} spacing={2}>
+              {links2}
+            </SimpleGrid>
+          </HoverCard.Dropdown>
+        </HoverCard>
+      );
+    }
+
+    if (link.disabled) {
+      return (
+        <a key={link.label} aria-disabled className={classes.link}>
+          <Group gap={5}>
+            <IconWrapper icon={link.icon} size={14} />
+            {link.label}
+          </Group>
+        </a>
+      );
+    }
+    if (link.link.startsWith("ext:")) {
+      return (
+        <Anchor key={link.label} href={link.link.replace("ext:", "")} className={classes.link} target="_blank">
+          <Group gap={5}>
+            <IconWrapper icon={link.icon} size={14} />
+            {link.label}
+          </Group>
+        </Anchor>
+      );
+    }
+    return (
       <NavLink key={link.label} to={link.link} className={classes.link}>
         <Group gap={5}>
           <IconWrapper icon={link.icon} size={14} />
           {link.label}
         </Group>
       </NavLink>
-    )
-  );
+    );
+  });
 
   return (
     <AppShellHeader className={classes.header}>

--- a/src/core/Header/SkeletonHeader.tsx
+++ b/src/core/Header/SkeletonHeader.tsx
@@ -1,94 +1,8 @@
-import { t } from "@lingui/core/macro";
-import { Anchor, AppShellHeader, Box, Burger, Container, Group, Text } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
-import {
-  IconBrandGithub,
-  IconClipboardCheck,
-  IconDatabase,
-  IconFileCertificate,
-  IconFolderBolt,
-  IconPackage,
-  IconSettings
-} from "@tabler/icons-react";
-import { useMemo } from "react";
-import { Link, NavLink } from "react-router";
-import IconWrapper from "../IconWrapper";
+import { AppShellHeader, Box, Container, Text } from "@mantine/core";
+import { Link } from "react-router";
 import classes from "./Header.module.css";
 
 export function SkeletonHeader() {
-  const [opened, { toggle }] = useDisclosure(false);
-
-  const links = useMemo(() => {
-    return [
-      {
-        link: "/snapshots",
-        label: t`Snapshots`,
-        disabled: true,
-        icon: IconPackage
-      },
-      {
-        link: "/mounts",
-        label: t`Mounts`,
-        disabled: true,
-        icon: IconFolderBolt
-      },
-      {
-        link: "/policies",
-        label: t`Policies`,
-        disabled: true,
-        icon: IconFileCertificate
-      },
-      {
-        link: "/tasks",
-        label: t`Tasks`,
-        icon: IconClipboardCheck,
-        disabled: true
-      },
-      {
-        link: "/repo",
-        label: t`Repository`,
-        icon: IconDatabase,
-        disabled: true
-      },
-      {
-        link: "/preferences",
-        label: t`Preferences`,
-        icon: IconSettings,
-        disabled: true
-      },
-      {
-        link: "ext:https://github.com/joachimdalen/kopia-alternate-ui",
-        label: "GitHub",
-        icon: IconBrandGithub
-      }
-    ];
-  }, []);
-
-  const items = links.map((link) =>
-    link.disabled ? (
-      <a key={link.label} aria-disabled className={classes.link}>
-        <Group gap={5}>
-          <IconWrapper icon={link.icon} size={14} />
-          {link.label}
-        </Group>
-      </a>
-    ) : link.link.startsWith("ext:") ? (
-      <Anchor key={link.label} href={link.link.replace("ext:", "")} className={classes.link} target="_blank">
-        <Group gap={5}>
-          <IconWrapper icon={link.icon} size={14} />
-          {link.label}
-        </Group>
-      </Anchor>
-    ) : (
-      <NavLink key={link.label} to={link.link} className={classes.link}>
-        <Group gap={5}>
-          <IconWrapper icon={link.icon} size={14} />
-          {link.label}
-        </Group>
-      </NavLink>
-    )
-  );
-
   return (
     <AppShellHeader className={classes.header}>
       <Container size="md" className={classes.inner}>
@@ -99,10 +13,6 @@ export function SkeletonHeader() {
             </Text>
           </Link>
         </Box>
-        <Group gap={5} visibleFrom="xs">
-          {items}
-        </Group>
-        <Burger opened={opened} onClick={toggle} hiddenFrom="xs" size="sm" />
       </Container>
     </AppShellHeader>
   );

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1096,6 +1096,22 @@ msgstr "Logs"
 msgid "Mail From"
 msgstr "Mail From"
 
+#: src/core/Header/Header.tsx:76
+msgid "Manage mounted snapshots"
+msgstr "Manage mounted snapshots"
+
+#: src/core/Header/Header.tsx:89
+msgid "Manage repository status and configuration"
+msgstr "Manage repository status and configuration"
+
+#: src/core/Header/Header.tsx:96
+msgid "Manage snapshot policies for this repository"
+msgstr "Manage snapshot policies for this repository"
+
+#: src/core/Header/Header.tsx:69
+msgid "Manage snapshots"
+msgstr "Manage snapshots"
+
 #: src/policies/modals/PolicyModal/constants.ts:140
 #: src/policies/modals/PolicyModal/tabs/SchedulingTab.tsx:109
 msgid "Manual Snapshots Only"
@@ -1173,8 +1189,7 @@ msgstr "Mounted at"
 msgid "Mounted Snapshots"
 msgstr "Mounted Snapshots"
 
-#: src/core/Header/Header.tsx:32
-#: src/core/Header/SkeletonHeader.tsx:31
+#: src/core/Header/Header.tsx:73
 msgid "Mounts"
 msgstr "Mounts"
 
@@ -1452,8 +1467,7 @@ msgstr "Pin Snapshot"
 msgid "Plain Text Format"
 msgstr "Plain Text Format"
 
-#: src/core/Header/Header.tsx:38
-#: src/core/Header/SkeletonHeader.tsx:37
+#: src/core/Header/Header.tsx:93
 #: src/policies/PoliciesPage.tsx:136
 msgid "Policies"
 msgstr "Policies"
@@ -1467,8 +1481,7 @@ msgstr "Port"
 msgid "Port number (e.g., 22)"
 msgstr "Port number (e.g., 22)"
 
-#: src/core/Header/Header.tsx:44
-#: src/core/Header/SkeletonHeader.tsx:55
+#: src/core/Header/Header.tsx:101
 #: src/preferences/PreferencesPage.tsx:14
 msgid "Preferences"
 msgstr "Preferences"
@@ -1532,8 +1545,7 @@ msgstr "Refresh"
 msgid "Remote"
 msgstr "Remote"
 
-#: src/core/Header/Header.tsx:43
-#: src/core/Header/SkeletonHeader.tsx:49
+#: src/core/Header/Header.tsx:82
 msgid "Repository"
 msgstr "Repository"
 
@@ -1822,8 +1834,8 @@ msgstr "Snapshot unmounted"
 msgid "Snapshot(s) deleted"
 msgstr "Snapshot(s) deleted"
 
-#: src/core/Header/Header.tsx:26
-#: src/core/Header/SkeletonHeader.tsx:25
+#: src/core/Header/Header.tsx:60
+#: src/core/Header/Header.tsx:66
 #: src/snapshot-history/components/SnapshotHistoryStats.tsx:83
 #: src/snapshot-history/SnapshotHistory.tsx:87
 #: src/snapshots/SnapshotsPage.tsx:136
@@ -1873,6 +1885,7 @@ msgstr "Started"
 msgid "Statistics"
 msgstr "Statistics"
 
+#: src/core/Header/Header.tsx:87
 #: src/tasks/TasksPage.tsx:203
 msgid "Status"
 msgstr "Status"
@@ -1902,8 +1915,7 @@ msgstr "Task cancelled"
 msgid "Task ID"
 msgstr "Task ID"
 
-#: src/core/Header/Header.tsx:42
-#: src/core/Header/SkeletonHeader.tsx:43
+#: src/core/Header/Header.tsx:100
 #: src/tasks/TasksPage.tsx:99
 msgid "Tasks"
 msgstr "Tasks"

--- a/src/locales/nb/messages.po
+++ b/src/locales/nb/messages.po
@@ -1096,6 +1096,22 @@ msgstr "Logger"
 msgid "Mail From"
 msgstr "Avsender"
 
+#: src/core/Header/Header.tsx:76
+msgid "Manage mounted snapshots"
+msgstr "Administrer monterte øyeblikksbilder"
+
+#: src/core/Header/Header.tsx:89
+msgid "Manage repository status and configuration"
+msgstr "Administrer status og konfigurasjon på oppbevaringsstedet"
+
+#: src/core/Header/Header.tsx:96
+msgid "Manage snapshot policies for this repository"
+msgstr "Administrer strategier for øyeblikksbilder"
+
+#: src/core/Header/Header.tsx:69
+msgid "Manage snapshots"
+msgstr "Administrer øyeblikksbilder"
+
 #: src/policies/modals/PolicyModal/constants.ts:140
 #: src/policies/modals/PolicyModal/tabs/SchedulingTab.tsx:109
 msgid "Manual Snapshots Only"
@@ -1173,8 +1189,7 @@ msgstr "Montert på"
 msgid "Mounted Snapshots"
 msgstr "Monterte øyeblikksbilder"
 
-#: src/core/Header/Header.tsx:32
-#: src/core/Header/SkeletonHeader.tsx:31
+#: src/core/Header/Header.tsx:73
 msgid "Mounts"
 msgstr "Monteringer"
 
@@ -1452,8 +1467,7 @@ msgstr "Fest Øyeblikksbilde"
 msgid "Plain Text Format"
 msgstr "Vanlig tekstformat"
 
-#: src/core/Header/Header.tsx:38
-#: src/core/Header/SkeletonHeader.tsx:37
+#: src/core/Header/Header.tsx:93
 #: src/policies/PoliciesPage.tsx:136
 msgid "Policies"
 msgstr "Strategier"
@@ -1467,8 +1481,7 @@ msgstr "Port"
 msgid "Port number (e.g., 22)"
 msgstr "Port nummer (e.g., 22)"
 
-#: src/core/Header/Header.tsx:44
-#: src/core/Header/SkeletonHeader.tsx:55
+#: src/core/Header/Header.tsx:101
 #: src/preferences/PreferencesPage.tsx:14
 msgid "Preferences"
 msgstr "Preferanser"
@@ -1532,8 +1545,7 @@ msgstr "Oppdater"
 msgid "Remote"
 msgstr "Ekstern"
 
-#: src/core/Header/Header.tsx:43
-#: src/core/Header/SkeletonHeader.tsx:49
+#: src/core/Header/Header.tsx:82
 msgid "Repository"
 msgstr "Oppbevaringssted"
 
@@ -1822,8 +1834,8 @@ msgstr "Øyeblikksbilde demontert"
 msgid "Snapshot(s) deleted"
 msgstr "Øyeblikksbilde(r) slettet"
 
-#: src/core/Header/Header.tsx:26
-#: src/core/Header/SkeletonHeader.tsx:25
+#: src/core/Header/Header.tsx:60
+#: src/core/Header/Header.tsx:66
 #: src/snapshot-history/components/SnapshotHistoryStats.tsx:83
 #: src/snapshot-history/SnapshotHistory.tsx:87
 #: src/snapshots/SnapshotsPage.tsx:136
@@ -1873,6 +1885,7 @@ msgstr "Staret"
 msgid "Statistics"
 msgstr "Statistikk"
 
+#: src/core/Header/Header.tsx:87
 #: src/tasks/TasksPage.tsx:203
 msgid "Status"
 msgstr "Status"
@@ -1902,8 +1915,7 @@ msgstr "Oppgave Kansellert"
 msgid "Task ID"
 msgstr "Oppgave ID"
 
-#: src/core/Header/Header.tsx:42
-#: src/core/Header/SkeletonHeader.tsx:43
+#: src/core/Header/Header.tsx:100
 #: src/tasks/TasksPage.tsx:99
 msgid "Tasks"
 msgstr "Oppgaver"


### PR DESCRIPTION
## Changes

Grouped some of the links in the header to allow better navigation of planned features.

<img width="719" height="226" alt="image" src="https://github.com/user-attachments/assets/97c7d8da-abb8-4960-a6ba-3143860d2696" />


### Checklist

- [x]  Files have been formatted - `npm run format:fix`
- [x] Languge files have been updated  - `npm run lang:extract`
- [x] Tests passes - `npm run test`