### PR TITLE
fix: cleanup some buttons and icons after framework update

### DIFF
--- a/src/core/Footer/ConnectionInfo.tsx
+++ b/src/core/Footer/ConnectionInfo.tsx
@@ -61,8 +61,8 @@ export function ConnectionInfo() {
                 <div>
                   <Tooltip label="Logout">
                     <ActionIcon
-                      variant="light"
-                      color="red"
+                      variant="subtle"
+                      color="red.5"
                       onClick={() => {
                         logoutFromServer(currentServer?.id);
                       }}

--- a/src/core/IconWrapper.tsx
+++ b/src/core/IconWrapper.tsx
@@ -12,7 +12,7 @@ export default function IconWrapper({
   size?: number;
   tooltip?: string;
 }) {
-  const icn = <Icon height={size} width={size} color={color && `var(--mantine-color-${color}-5)`} stroke={2} />;
+  const icn = <Icon height={size} width={size} color={color && `var(--mantine-color-${color}-5)`} />;
   if (tooltip) return <Tooltip label={tooltip}>{icn}</Tooltip>;
   return icn;
 }

--- a/src/core/MenuButton/MenuButton.tsx
+++ b/src/core/MenuButton/MenuButton.tsx
@@ -54,7 +54,7 @@ export function MenuButton({
               </Group>
             )}
           </span>
-          <IconChevronDown size={16} className={classes.icon} stroke={1.5} />
+          <IconChevronDown size={16} className={classes.icon} />
         </UnstyledButton>
       </Menu.Target>
       <Menu.Dropdown>{items}</Menu.Dropdown>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -109,12 +109,12 @@ msgid "Advanced Options"
 msgstr "Advanced Options"
 
 #: src/policies/modals/PolicyModal/constants.ts:170
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:68
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:69
 msgid "After Folder"
 msgstr "After Folder"
 
 #: src/policies/modals/PolicyModal/constants.ts:184
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:73
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:74
 msgid "After Snapshot"
 msgstr "After Snapshot"
 
@@ -176,12 +176,12 @@ msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
 #: src/policies/modals/PolicyModal/constants.ts:163
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:27
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:28
 msgid "Before Folder"
 msgstr "Before Folder"
 
 #: src/policies/modals/PolicyModal/constants.ts:177
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:27
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:28
 msgid "Before Snapshot"
 msgstr "Before Snapshot"
 
@@ -257,15 +257,15 @@ msgstr "Close"
 
 #: src/policies/modals/PolicyModal/constants.ts:172
 #: src/policies/modals/PolicyModal/constants.ts:186
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:93
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:98
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:94
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:99
 msgid "Command Mode - After"
 msgstr "Command Mode - After"
 
 #: src/policies/modals/PolicyModal/constants.ts:165
 #: src/policies/modals/PolicyModal/constants.ts:179
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:52
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:56
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:53
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:57
 msgid "Command Mode - Before"
 msgstr "Command Mode - Before"
 
@@ -326,7 +326,7 @@ msgstr "Connect to repository"
 msgid "Connected as"
 msgstr "Connected as"
 
-#: src/core/Footer/ConnectionInfo.tsx:53
+#: src/core/Footer/ConnectionInfo.tsx:54
 msgid "Connected to"
 msgstr "Connected to"
 
@@ -579,7 +579,7 @@ msgstr "Edit pushover notification"
 msgid "Edit script"
 msgstr "Edit script"
 
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:15
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:16
 #: src/policies/modals/PolicyModal/policy-inputs/PolicyCompressionInput.tsx:91
 #: src/policies/modals/PolicyModal/policy-inputs/PolicyInheritYesNoPolicyInput.tsx:46
 #: src/policies/modals/PolicyModal/policy-inputs/PolicyLogDetailsInput.tsx:59
@@ -742,10 +742,10 @@ msgstr "Error Correction Overhead"
 msgid "Error Handling"
 msgstr "Error Handling"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:53
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:94
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:57
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:99
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:54
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:95
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:58
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:100
 msgid "Essential (must succeed; default behavior), optional (failures are tolerated), or async (Kopia will start the action but not wait for it to finish)"
 msgstr "Essential (must succeed; default behavior), optional (failures are tolerated), or async (Kopia will start the action but not wait for it to finish)"
 
@@ -836,7 +836,7 @@ msgstr "Hash Algorithm"
 msgid "Helps to distinguish between multiple connected repositories"
 msgstr "Helps to distinguish between multiple connected repositories"
 
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:44
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:45
 #: src/policies/PoliciesPage.tsx:193
 #: src/repo/sections/SFTPServerRepo.tsx:52
 #: src/repo/sections/SFTPServerRepo.tsx:160
@@ -895,10 +895,10 @@ msgstr "Ignore directories containing CACHEDIR.TAG and similar"
 msgid "Ignore Directory Errors"
 msgstr "Ignore Directory Errors"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:56
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:97
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:60
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:102
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:57
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:98
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:61
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:103
 msgid "Ignore failures"
 msgstr "Ignore failures"
 
@@ -1197,10 +1197,10 @@ msgstr "Mounts"
 msgid "must be specified using global, user, or host policy"
 msgstr "must be specified using global, user, or host policy"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:55
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:96
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:59
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:101
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:56
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:97
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:60
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:102
 msgid "Must Succeed"
 msgstr "Must Succeed"
 
@@ -1349,10 +1349,10 @@ msgstr "Only one of Password, Path to key file or Key Data must be set"
 msgid "Only one of Path to known_hosts File or Known Hosts Data must be set"
 msgstr "Only one of Path to known_hosts File or Known Hosts Data must be set"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:34
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:75
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:34
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:80
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:35
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:76
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:35
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:81
 msgid "Open in large edit"
 msgstr "Open in large edit"
 
@@ -1423,7 +1423,7 @@ msgid "Paste JSON credentials here"
 msgstr "Paste JSON credentials here"
 
 #: src/policies/modals/CreatePolicyModal/CreatePolicyModal.tsx:115
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:51
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:52
 #: src/policies/PoliciesPage.tsx:198
 #: src/repo/sections/SFTPServerRepo.tsx:55
 #: src/repo/sections/SFTPServerRepo.tsx:189
@@ -1603,10 +1603,10 @@ msgstr "Retention"
 msgid "Root"
 msgstr "Root"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:58
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:99
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:62
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:104
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:59
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:100
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:63
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:105
 msgid "Run asynchronously, ignore failures"
 msgstr "Run asynchronously, ignore failures"
 
@@ -1650,19 +1650,19 @@ msgstr "Scan only one filesystem"
 msgid "Scheduling"
 msgstr "Scheduling"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:69
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:70
 msgid "Script to run after folder"
 msgstr "Script to run after folder"
 
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:74
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:75
 msgid "Script to run after snapshot"
 msgstr "Script to run after snapshot"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:28
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:29
 msgid "Script to run before folder"
 msgstr "Script to run before folder"
 
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:28
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:29
 msgid "Script to run before snapshot"
 msgstr "Script to run before snapshot"
 
@@ -1703,8 +1703,8 @@ msgstr "Send test notification"
 msgid "sender email address"
 msgstr "sender email address"
 
-#: src/core/Footer/ConnectionInfo.tsx:33
-#: src/core/Footer/ConnectionInfo.tsx:47
+#: src/core/Footer/ConnectionInfo.tsx:34
+#: src/core/Footer/ConnectionInfo.tsx:48
 msgid "Server"
 msgstr "Server"
 
@@ -1722,7 +1722,7 @@ msgstr "Server Endpoint"
 msgid "Server Password"
 msgstr "Server Password"
 
-#: src/core/Footer/ConnectionInfo.tsx:81
+#: src/core/Footer/ConnectionInfo.tsx:82
 msgid "SERVERS"
 msgstr "SERVERS"
 
@@ -1963,22 +1963,22 @@ msgstr "Time Of Day"
 
 #: src/policies/modals/PolicyModal/constants.ts:171
 #: src/policies/modals/PolicyModal/constants.ts:185
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:84
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:89
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:85
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:90
 msgid "Timeout - After"
 msgstr "Timeout - After"
 
 #: src/policies/modals/PolicyModal/constants.ts:164
 #: src/policies/modals/PolicyModal/constants.ts:178
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:43
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:47
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:44
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:48
 msgid "Timeout - Before"
 msgstr "Timeout - Before"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:44
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:85
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:48
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:90
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:45
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:86
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:49
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:91
 msgid "Timeout in seconds before Kopia kills the process"
 msgstr "Timeout in seconds before Kopia kills the process"
 
@@ -2083,7 +2083,7 @@ msgstr "User"
 
 #: src/core/context/LoginModal.tsx:60
 #: src/core/context/LoginModal.tsx:62
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:38
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:39
 #: src/policies/PoliciesPage.tsx:188
 #: src/repo/ConnectRepoSection.tsx:138
 #: src/repo/CreateRepoSection.tsx:203
@@ -2094,7 +2094,7 @@ msgstr "User"
 msgid "Username"
 msgstr "Username"
 
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:26
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:27
 msgid "Value defined in policy"
 msgstr "Value defined in policy"
 

--- a/src/locales/nb/messages.po
+++ b/src/locales/nb/messages.po
@@ -109,12 +109,12 @@ msgid "Advanced Options"
 msgstr "Avanserte valg"
 
 #: src/policies/modals/PolicyModal/constants.ts:170
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:68
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:69
 msgid "After Folder"
 msgstr "Etter mappe"
 
 #: src/policies/modals/PolicyModal/constants.ts:184
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:73
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:74
 msgid "After Snapshot"
 msgstr "Etter øyeblikksbilde"
 
@@ -176,12 +176,12 @@ msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
 #: src/policies/modals/PolicyModal/constants.ts:163
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:27
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:28
 msgid "Before Folder"
 msgstr "Før Mappe"
 
 #: src/policies/modals/PolicyModal/constants.ts:177
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:27
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:28
 msgid "Before Snapshot"
 msgstr "Før Øyeblikksbilde"
 
@@ -257,15 +257,15 @@ msgstr "Lukk"
 
 #: src/policies/modals/PolicyModal/constants.ts:172
 #: src/policies/modals/PolicyModal/constants.ts:186
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:93
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:98
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:94
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:99
 msgid "Command Mode - After"
 msgstr "Kommandomodus – Etter"
 
 #: src/policies/modals/PolicyModal/constants.ts:165
 #: src/policies/modals/PolicyModal/constants.ts:179
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:52
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:56
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:53
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:57
 msgid "Command Mode - Before"
 msgstr "Kommandomodus – Før"
 
@@ -326,7 +326,7 @@ msgstr "Koble til oppbevaringsstedet"
 msgid "Connected as"
 msgstr "Koblet til som"
 
-#: src/core/Footer/ConnectionInfo.tsx:53
+#: src/core/Footer/ConnectionInfo.tsx:54
 msgid "Connected to"
 msgstr "Koblet til"
 
@@ -579,7 +579,7 @@ msgstr "Rediger pushover notifikasjon"
 msgid "Edit script"
 msgstr "Rediger skript"
 
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:15
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:16
 #: src/policies/modals/PolicyModal/policy-inputs/PolicyCompressionInput.tsx:91
 #: src/policies/modals/PolicyModal/policy-inputs/PolicyInheritYesNoPolicyInput.tsx:46
 #: src/policies/modals/PolicyModal/policy-inputs/PolicyLogDetailsInput.tsx:59
@@ -742,10 +742,10 @@ msgstr "Feilretting Overhead"
 msgid "Error Handling"
 msgstr "Feilhåndtering"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:53
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:94
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:57
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:99
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:54
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:95
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:58
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:100
 msgid "Essential (must succeed; default behavior), optional (failures are tolerated), or async (Kopia will start the action but not wait for it to finish)"
 msgstr "Essensiell (må lykkes; standardoppførsel), valgfri (feil tolereres), eller asynkron (Kopia starter handlingen, men venter ikke til den er ferdig)"
 
@@ -836,7 +836,7 @@ msgstr "Hash-algoritme"
 msgid "Helps to distinguish between multiple connected repositories"
 msgstr "Hjelper med å skille mellom flere tilkoblede oppbevaringssteder"
 
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:44
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:45
 #: src/policies/PoliciesPage.tsx:193
 #: src/repo/sections/SFTPServerRepo.tsx:52
 #: src/repo/sections/SFTPServerRepo.tsx:160
@@ -895,10 +895,10 @@ msgstr "Ignorer mapper som inneholder CACHEDIR.TAG og lignende"
 msgid "Ignore Directory Errors"
 msgstr "Ignorer mappe feil"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:56
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:97
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:60
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:102
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:57
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:98
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:61
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:103
 msgid "Ignore failures"
 msgstr "Ignorer feil"
 
@@ -1197,10 +1197,10 @@ msgstr "Monteringer"
 msgid "must be specified using global, user, or host policy"
 msgstr "må spesifiseres ved hjelp av global, bruker- eller vertsstrategier"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:55
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:96
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:59
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:101
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:56
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:97
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:60
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:102
 msgid "Must Succeed"
 msgstr "Må lykkes"
 
@@ -1349,10 +1349,10 @@ msgstr "Kun en av Passord, Sti til nøkkelfilen eller Nøkkeldata kan være defi
 msgid "Only one of Path to known_hosts File or Known Hosts Data must be set"
 msgstr "Kun en av Sti til known_hosts-filen eller Kjente vertsdata kan være definert"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:34
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:75
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:34
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:80
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:35
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:76
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:35
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:81
 msgid "Open in large edit"
 msgstr "Åpne i stort vindu"
 
@@ -1423,7 +1423,7 @@ msgid "Paste JSON credentials here"
 msgstr "Lim inn JSON-legitimasjon her"
 
 #: src/policies/modals/CreatePolicyModal/CreatePolicyModal.tsx:115
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:51
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:52
 #: src/policies/PoliciesPage.tsx:198
 #: src/repo/sections/SFTPServerRepo.tsx:55
 #: src/repo/sections/SFTPServerRepo.tsx:189
@@ -1603,10 +1603,10 @@ msgstr "Bevaring"
 msgid "Root"
 msgstr "Root"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:58
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:99
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:62
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:104
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:59
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:100
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:63
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:105
 msgid "Run asynchronously, ignore failures"
 msgstr "Kjør asynkront, ignorer feil"
 
@@ -1650,19 +1650,19 @@ msgstr "Skann bare ett filsystem"
 msgid "Scheduling"
 msgstr "Planlegging"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:69
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:70
 msgid "Script to run after folder"
 msgstr "Skript som skal kjøres etter mappen"
 
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:74
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:75
 msgid "Script to run after snapshot"
 msgstr "Skript som skal kjøres etter øyeblikksbilde"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:28
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:29
 msgid "Script to run before folder"
 msgstr "Skript som skal kjøres før mappen"
 
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:28
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:29
 msgid "Script to run before snapshot"
 msgstr "Skript som skal kjøres før øyeblikksbilde"
 
@@ -1703,8 +1703,8 @@ msgstr "Send test notifikasjon"
 msgid "sender email address"
 msgstr "Avsender epost adresse"
 
-#: src/core/Footer/ConnectionInfo.tsx:33
-#: src/core/Footer/ConnectionInfo.tsx:47
+#: src/core/Footer/ConnectionInfo.tsx:34
+#: src/core/Footer/ConnectionInfo.tsx:48
 msgid "Server"
 msgstr "Server"
 
@@ -1722,7 +1722,7 @@ msgstr "Server endepunkt"
 msgid "Server Password"
 msgstr "Server Passord"
 
-#: src/core/Footer/ConnectionInfo.tsx:81
+#: src/core/Footer/ConnectionInfo.tsx:82
 msgid "SERVERS"
 msgstr "SERVERE"
 
@@ -1963,22 +1963,22 @@ msgstr "Tid på dagen"
 
 #: src/policies/modals/PolicyModal/constants.ts:171
 #: src/policies/modals/PolicyModal/constants.ts:185
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:84
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:89
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:85
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:90
 msgid "Timeout - After"
 msgstr "Tidsavbrudd - Etter"
 
 #: src/policies/modals/PolicyModal/constants.ts:164
 #: src/policies/modals/PolicyModal/constants.ts:178
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:43
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:47
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:44
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:48
 msgid "Timeout - Before"
 msgstr "Tidsavbrudd - Før"
 
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:44
-#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:85
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:48
-#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:90
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:45
+#: src/policies/modals/PolicyModal/tabs/FolderActionsTab.tsx:86
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:49
+#: src/policies/modals/PolicyModal/tabs/SnapshotActionsTab.tsx:91
 msgid "Timeout in seconds before Kopia kills the process"
 msgstr "Tidsavbrudd i sekunder før Kopia avslutter prosessen"
 
@@ -2083,7 +2083,7 @@ msgstr "Bruker"
 
 #: src/core/context/LoginModal.tsx:60
 #: src/core/context/LoginModal.tsx:62
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:38
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:39
 #: src/policies/PoliciesPage.tsx:188
 #: src/repo/ConnectRepoSection.tsx:138
 #: src/repo/CreateRepoSection.tsx:203
@@ -2094,7 +2094,7 @@ msgstr "Bruker"
 msgid "Username"
 msgstr "Brukernavn"
 
-#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:26
+#: src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx:27
 msgid "Value defined in policy"
 msgstr "Verdi definert i strategi"
 

--- a/src/policies/PoliciesPage.tsx
+++ b/src/policies/PoliciesPage.tsx
@@ -220,8 +220,8 @@ function PoliciesPage() {
               render: (item) => (
                 <Tooltip label={t`Edit`}>
                   <ActionIcon
-                    variant="light"
-                    color="yellow"
+                    variant="subtle"
+                    color="yellow.5"
                     onClick={() =>
                       setAction({
                         action: "edit",

--- a/src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx
+++ b/src/policies/modals/PolicyModal/components/PolicyEffectiveLabel.tsx
@@ -17,7 +17,7 @@ export default function PolicyEffectiveLabel({ sourceInfo }: Props) {
       </Text>
       <Popover width={400} position="bottom" withArrow shadow="md">
         <Popover.Target>
-          <ActionIcon variant="subtle" color="blue" size="xs" p={0}>
+          <ActionIcon variant="subtle" color="blue.5" size="xs" p={0}>
             <IconWrapper icon={IconInfoCircleFilled} size={12} color="blue" />
           </ActionIcon>
         </Popover.Target>

--- a/src/preferences/NotificationsSection.tsx
+++ b/src/preferences/NotificationsSection.tsx
@@ -66,30 +66,25 @@ function NotificationsSection() {
         <Group>
           <Menu transitionProps={{ transition: "pop-top-right" }} position="top-end" withinPortal radius="md">
             <Menu.Target>
-              <Button
-                rightSection={<IconChevronDown size={18} stroke={1.5} />}
-                pr={12}
-                variant="subtle"
-                color="green.5"
-              >
+              <Button rightSection={<IconChevronDown size={18} />} pr={12} variant="subtle" color="green.5">
                 <Trans>Create new</Trans>
               </Button>
             </Menu.Target>
             <Menu.Dropdown>
               <Menu.Item
-                leftSection={<IconWebhook size={16} stroke={1.5} />}
+                leftSection={<IconWebhook size={16} />}
                 onClick={() => setAction({ action: "new", item: { type: "webhook" } })}
               >
                 <Trans>Webhook</Trans>
               </Menu.Item>
               <Menu.Item
-                leftSection={<IconMail size={16} stroke={1.5} />}
+                leftSection={<IconMail size={16} />}
                 onClick={() => setAction({ action: "new", item: { type: "email" } })}
               >
                 <Trans>Email</Trans>
               </Menu.Item>
               <Menu.Item
-                leftSection={<IconBrandPushover size={16} stroke={1.5} />}
+                leftSection={<IconBrandPushover size={16} />}
                 onClick={() => setAction({ action: "new", item: { type: "pushover" } })}
               >
                 <Trans>Pushover</Trans>

--- a/src/snapshot-directory/SnapshotDirectory.tsx
+++ b/src/snapshot-directory/SnapshotDirectory.tsx
@@ -133,7 +133,7 @@ function SnapshotDirectory() {
             <TextInput
               size="sm"
               placeholder={t`Search files or folder (current level)`}
-              leftSection={<IconSearch size={18} stroke={1.5} />}
+              leftSection={<IconSearch size={18} />}
               value={query}
               onChange={setQuery}
             />
@@ -162,7 +162,7 @@ function SnapshotDirectory() {
                 <CopyButton value={mount.path} timeout={2000}>
                   {({ copied, copy }) => (
                     <Tooltip label={copied ? "Copied" : "Copy"} withArrow position="right">
-                      <ActionIcon color={copied ? "teal" : "gray"} variant="light" onClick={copy}>
+                      <ActionIcon color={copied ? "teal.5" : "gray.5"} variant="subtle" onClick={copy}>
                         {copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
                       </ActionIcon>
                     </Tooltip>
@@ -245,8 +245,8 @@ function SnapshotDirectory() {
                 !item.obj.startsWith("k") && (
                   <Tooltip label={t`Download`}>
                     <ActionIcon
-                      variant="light"
-                      color="blue"
+                      variant="subtle"
+                      color="blue.5"
                       component="a"
                       href={`/api/v1/objects/${item.obj}?fname=${encodeURIComponent(item.name)}`}
                     >

--- a/src/snapshot-history/SnapshotHistory.tsx
+++ b/src/snapshot-history/SnapshotHistory.tsx
@@ -228,8 +228,8 @@ function SnapshotHistory() {
                 <Group gap={4} justify="right" wrap="nowrap">
                   <Tooltip label={t`Update description`}>
                     <ActionIcon
-                      variant="light"
-                      color="blue"
+                      variant="subtle"
+                      color="blue.5"
                       onClick={() =>
                         setItemAction({
                           item,
@@ -241,7 +241,7 @@ function SnapshotHistory() {
                     </ActionIcon>
                   </Tooltip>
                   <Tooltip label={t`Add pin to prevent snapshot deletion`}>
-                    <ActionIcon variant="light" color="grape" onClick={() => setItemAction({ item, action: "pin" })}>
+                    <ActionIcon variant="subtle" color="grape.5" onClick={() => setItemAction({ item, action: "pin" })}>
                       <IconPin size={18} />
                     </ActionIcon>
                   </Tooltip>

--- a/src/snapshot-mounts/SnapshotMountsPage.tsx
+++ b/src/snapshot-mounts/SnapshotMountsPage.tsx
@@ -92,8 +92,8 @@ function SnapshotMountsPage() {
               render: (item) => (
                 <Tooltip label={t`Unmount`}>
                   <ActionIcon
-                    variant="light"
-                    color="red"
+                    variant="subtle"
+                    color="red.5"
                     onClick={() => unMountAction.execute(item.root, item.root)}
                     loading={unMountAction.loading && unMountAction.loadingKey === item.root}
                   >

--- a/src/snapshots/SnapshotsPage.tsx
+++ b/src/snapshots/SnapshotsPage.tsx
@@ -298,8 +298,8 @@ function SnapshotsPage() {
                         {item.status !== "REMOTE" && (
                           <Tooltip label={t`Snapshot Now`}>
                             <ActionIcon
-                              variant="light"
-                              color="green"
+                              variant="subtle"
+                              color="green.5"
                               loading={newSnapshotActions.loading}
                               onClick={() => newSnapshotActions.execute(item.source)}
                             >
@@ -315,8 +315,8 @@ function SnapshotsPage() {
                               pathname: "/policies",
                               search: `userName=${item.source.userName}&host=${item.source.host}&path=${encodeURIComponent(item.source.path)}&viewPolicy=true`
                             }}
-                            variant="light"
-                            color="grape"
+                            variant="subtle"
+                            color="grape.5"
                           >
                             <IconWrapper icon={IconFileCertificate} size={16} />
                           </ActionIcon>

--- a/src/snapshots/modals/NewSnapshotModal.tsx
+++ b/src/snapshots/modals/NewSnapshotModal.tsx
@@ -111,7 +111,7 @@ export default function NewSnapshotModal({ onCancel, onSnapshotted }: Props) {
                 loading={resolvePathAction.loading}
                 onClick={() => resolvePathAction.execute(form.values.path)}
               >
-                <IconSearch size={14} stroke={1.5} />
+                <IconSearch size={14} />
               </ActionIcon>
             }
             {...form.getInputProps("path")}

--- a/src/tasks/TasksPage.tsx
+++ b/src/tasks/TasksPage.tsx
@@ -160,7 +160,7 @@ function TasksPage() {
             <TextInput
               size="sm"
               placeholder={t`Search tasks`}
-              leftSection={<IconSearch size={18} stroke={1.5} />}
+              leftSection={<IconSearch size={18} />}
               value={query}
               onChange={setQuery}
             />
@@ -227,8 +227,8 @@ function TasksPage() {
                     })}
                   >
                     <ActionIcon
-                      variant="light"
-                      color="red"
+                      variant="subtle"
+                      color="red.5"
                       onClick={() => cancelTaskAction.execute(item.id, item.id)}
                       loading={cancelTaskAction.loading && cancelTaskAction.loadingKey === item.id}
                     >


### PR DESCRIPTION
## Changes

- Cleanup some buttons, `light` -> `subtle`
- Remove `stroke` override from icons

### Checklist

- [x]  Files have been formatted - `npm run format:fix`
- [x] Languge files have been updated  - `npm run lang:extract`
- [x] Tests passes - `npm run test`