### PR TITLE
fix(repo): show connect when repo exists

### DIFF
--- a/src/repo/ConfigureRepoSection.tsx
+++ b/src/repo/ConfigureRepoSection.tsx
@@ -173,7 +173,7 @@ function ConfigureRepoSection() {
   const checkRepoAction = useApiRequest({
     action: (data?: CheckRepoRequest) => kopiaService.repoExists(data!),
     onReturn() {
-      form.setFieldValue("confirmCreate", true);
+      form.setFieldValue("confirmCreate", false);
       setActive(2);
     },
     handleError(data) {


### PR DESCRIPTION
## Changes

Fix create section showing instead of connect section when repo exists

### Checklist

- [x]  Files have been formatted - `npm run format:fix`
- [x] Languge files have been updated  - `npm run lang:extract`
- [x] Tests passes - `npm run test`